### PR TITLE
Adição de página de detalhes do país com informações essenciais

### DIFF
--- a/frontend/src/components/CountryCardExtend/index.jsx
+++ b/frontend/src/components/CountryCardExtend/index.jsx
@@ -1,0 +1,14 @@
+import { Container } from './style';
+
+export function CountryCardExtend({flag, name, capital, area, population, ...rest}) {
+    return (
+        <Container {...rest}>
+            <img src={flag} alt={name} />
+            <h2>{name}</h2>
+
+            <p><span>Capital: </span>{capital}</p>
+            <p><span>Área: </span>{area}</p>
+            <p><span>População: </span>{population}</p>
+        </Container>
+    )
+}

--- a/frontend/src/components/CountryCardExtend/style.js
+++ b/frontend/src/components/CountryCardExtend/style.js
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+import theme from "../../styles/theme";
+
+export const  Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    display: inline-block;
+    width: 10rem;
+    transition: 0.3s;
+    height: 12rem;
+    background-color: ${theme.COLORS.BG_50};
+    justify-items: center;
+    padding: 0.5rem;
+    border-radius: 12px;
+
+    img {
+        width: 9rem;
+        height: 6rem;
+        object-fit: cover;
+        border-radius: 8px;
+    }
+
+    h2 {
+        font-size: 1rem;
+        width: 100%;
+        font-weight: 600;
+        text-align: center;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        margin-bottom: 0.4rem;
+    }
+    
+    p > span{
+        font-weight: 600;
+    }
+
+    p{
+        font-size: 0.8rem;
+        text-align: center;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        width: 100%;
+        white-space: nowrap;
+    }
+
+    &:hover {
+        cursor: pointer;
+        filter: brightness(0.9);
+    }
+
+    &:active {
+        transform: scale(0.9);
+    }
+`;

--- a/frontend/src/pages/CountryDetails/index.jsx
+++ b/frontend/src/pages/CountryDetails/index.jsx
@@ -47,7 +47,7 @@ export function CountryDetails() {
       <MainContent>
         <SectionTitle>Descrição Geral</SectionTitle>
         <Description>
-          Localizado em [continente/região], este território abrange uma área de aproximadamente
+          (EM DESENVOLVIMENTO) Localizado em [continente/região], este território abrange uma área de aproximadamente
           [área em km²] e possui uma população estimada de [número de habitantes]. Sua capital é
           [nome da capital], e o idioma oficial é [idioma]. Conhecido por [característica notável],
           sua economia é impulsionada por setores como [principais setores econômicos].
@@ -67,13 +67,14 @@ export function CountryDetails() {
           <GridItem>
             <SectionTitle>Fronteiras</SectionTitle>
             <ul>
-              <li>Nome País</li>
-              <li>Nome País</li>
-              <li>Nome País</li>
+              <li>Em Desenvolvimento</li>
+              <li>Em Desenvolvimento</li>
+              <li>Em Desenvolvimento</li>
             </ul>
           </GridItem>
           <GridItem>
             <SectionTitle>Mapa</SectionTitle>
+            <p>Em Desenvolvimento</p>
           </GridItem>
         </Grid>
       </MainContent>

--- a/frontend/src/pages/CountryDetails/index.jsx
+++ b/frontend/src/pages/CountryDetails/index.jsx
@@ -1,0 +1,82 @@
+import { Button } from "../../components/Button";
+import { Container, Sidebar, BackButton, CountryName, InfoList, InfoItem, MainContent, SectionTitle, Description, Grid, GridItem } from "./styles";
+import { IoLocationSharp, IoPerson, } from "react-icons/io5";
+import { TiWorld } from "react-icons/ti";
+import { MdAttachMoney } from "react-icons/md";
+import { FaClock } from "react-icons/fa";
+import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { api } from "../../services/api";
+
+
+export function CountryDetails() {
+
+  const navigate = useNavigate();
+  const {ccn3} = useParams();
+  const [country, setCountry] = useState({});
+  
+  useEffect(() => {
+    async function getCountry() {
+      console.log(ccn3);
+      const response = await api.get(`/countries/${ccn3}`);
+      setCountry(response.data);
+    }
+    getCountry();
+  }, [ccn3]);
+
+  
+  return (
+    <Container>
+      {/* Sidebar */}
+      <Sidebar>
+        <BackButton onClick={()=> navigate(-1)}>← Voltar</BackButton>
+        <img src={country.flag} alt={`Bandeira do ${country.name}`} />
+        <CountryName>{country.name || "País"}</CountryName>
+        <InfoList>
+          <InfoItem><TiWorld/> {country.continents || "Continente"}</InfoItem>
+          <InfoItem><IoLocationSharp/>{country.capital || "Capital"}</InfoItem>
+          <InfoItem><IoPerson/> { country.population || "Nº População"}</InfoItem>
+          <InfoItem><MdAttachMoney/> {(country.currency && Object.values(country.currency)[0]?.name) || "Moeda"} ({ (country.currency && Object.values(country.currency)[0]?.symbol) || "Símbolo"})</InfoItem>
+          <InfoItem><FaClock/> { country.timezones ||"Fuso horário Principal"}</InfoItem>
+        </InfoList>
+        <Button>★ Remover dos Favoritos</Button>
+      </Sidebar>
+
+      {/* Main Content */}
+      <MainContent>
+        <SectionTitle>Descrição Geral</SectionTitle>
+        <Description>
+          Localizado em [continente/região], este território abrange uma área de aproximadamente
+          [área em km²] e possui uma população estimada de [número de habitantes]. Sua capital é
+          [nome da capital], e o idioma oficial é [idioma]. Conhecido por [característica notável],
+          sua economia é impulsionada por setores como [principais setores econômicos].
+        </Description>
+
+        <Grid>
+          <GridItem>
+            <SectionTitle>Línguas</SectionTitle>
+            <ul>
+              {country.languages && Object.values(country.languages).map((language, index) => (
+
+                <li key={index}>{language}</li>
+
+              ))}
+            </ul>
+          </GridItem>
+          <GridItem>
+            <SectionTitle>Fronteiras</SectionTitle>
+            <ul>
+              <li>Nome País</li>
+              <li>Nome País</li>
+              <li>Nome País</li>
+            </ul>
+          </GridItem>
+          <GridItem>
+            <SectionTitle>Mapa</SectionTitle>
+          </GridItem>
+        </Grid>
+      </MainContent>
+    </Container>
+  );
+}

--- a/frontend/src/pages/CountryDetails/styles.js
+++ b/frontend/src/pages/CountryDetails/styles.js
@@ -1,0 +1,106 @@
+import styled from "styled-components";
+
+// Estilização com styled-components
+export const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  height: 100vh;
+  font-family: Arial, sans-serif;
+`;
+
+export const Sidebar = styled.div`
+  width: 25%;
+  padding: 1.25rem;
+  background-color: #f4f4f4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+
+  img {
+    width: 15rem;
+    height: 10rem;
+    object-fit: cover;
+    object-position: center;
+    border-radius: 0.7rem;
+  }
+`;
+
+export const BackButton = styled.button`
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-bottom: 2rem;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const CountryName = styled.h2`
+  font-size: 18px;
+  margin: 10px 0;
+`;
+
+export const InfoList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0.60rem 0;
+  width: 100%;
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+export const InfoItem = styled.li`
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+
+  & svg {
+    font-size: 1.25rem;
+    margin-right: 0.5rem;
+  }
+`;
+
+export const MainContent = styled.div`
+  flex: 1;
+  padding: 4rem;
+`;
+
+export const SectionTitle = styled.h3`
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+
+  border-bottom: 1px solid #000;
+`;
+
+export const Description = styled.p`
+  font-size: 1rem;
+  line-height: 1.6;
+  margin-bottom: 3rem;
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
+`;
+
+export const GridItem = styled.div`
+  padding: 1rem;
+
+  ul {
+    padding: 0.5rem 1rem;
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+  }
+`;

--- a/frontend/src/pages/Homepage/index.jsx
+++ b/frontend/src/pages/Homepage/index.jsx
@@ -5,10 +5,11 @@ import { Container, Content, CountryList } from "./styles";
 import { api } from "../../services/api";
 import { useState } from "react";
 import { useEffect } from "react";
+import { useNavigate } from "react-router";
 
 export function Homepage() {
 
-    
+    const navigate = useNavigate();
     const [countries, setCountries] = useState([]);
     const [search, setSearch] = useState("");
 
@@ -34,7 +35,7 @@ export function Homepage() {
                 <CountryList>
                     {countries && countries.map((country, index) => (
 
-                        <CountryCard key={index} name={country.name} flag={country.flag}/>
+                        <CountryCard key={index} name={country.name} flag={country.flag}  onClick={() => navigate(`/country/${country.ccn3}`)}/>
 
                     ))}
                 </CountryList>

--- a/frontend/src/routes/app.routes.jsx
+++ b/frontend/src/routes/app.routes.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import {Homepage} from '../pages/Homepage';
+import {CountryDetails} from '../pages/CountryDetails';
 
 
 export function AppRoutes() {
@@ -7,6 +8,7 @@ export function AppRoutes() {
         <Routes>
             <Route path="/" element={<Homepage/>}/>
             <Route path="/login" element={<Navigate to="/"/>}/>
+            <Route path="/country/:ccn3" element={<CountryDetails/>}/>
         </Routes>
     )
 }


### PR DESCRIPTION
## 📌 Descrição
Esta pull request adiciona a funcionalidade de exibição dos detalhes de um país no frontend, incluindo um novo componente de card expandido e melhorias na navegação.

Esta PR resolve parte das funcionalidades relacionadas à issue #2 .

## 🔥 O que foi feito?
🎨 Frontend
✅ Criado componente de card de país com mais informações 🏷️
✅ Criada página de detalhes do país com informações expandidas 📜
✅ Adicionada rota para a página de detalhes no sistema de navegação 🚀
✅ Implementada navegação ao clicar em um país na homepage 🔄
✅ Indicação visual para os campos que ainda estão em desenvolvimento ⚠️

As informações já disponíveis para visualização na página de detalhes do país incluem:

✅ Nome do país 🏷️
✅ Bandeira 🏳️
✅ Capital 🏛️ (Atentar que estar em inglês)
✅ Continente 🌍
✅ População 👥
✅ Área total 📏
✅ Idiomas falados 🗣️ (Atentar que estar em inglês)
✅ Moeda oficial 💰 (Atentar que está em inglês)
✅ Fuso horário ⏰